### PR TITLE
Fixing small bug in PMNS_Decay

### DIFF
--- a/PMNS_Base.cxx
+++ b/PMNS_Base.cxx
@@ -907,7 +907,7 @@ std::vector<complexD> PMNS_Base::GetMassEigenstate(int mi){
 ///
 /// @param i,j - the indices of the rotation ij
 ///
-void PMNS_Base::RotateH(int i,int j){
+void PMNS_Base::RotateH(int i,int j,std::vector< std::vector<complexD> >& Ham){
 
   // Do nothing if angle is zero
   if(fTheta[i][j]==0) return;
@@ -926,61 +926,61 @@ void PMNS_Base::RotateH(int i,int j){
     if(i>0){
       // Top columns
       for(int k=0; k<i; k++){
-        fHmsBufferC = fHms[k][i];
+        fHmsBufferC = Ham[k][i];
 
-        fHms[k][i] *= fCosBuffer;
-        fHms[k][i] += fHms[k][j] * fSinBuffer * conj(fExpBuffer);
+        Ham[k][i] *= fCosBuffer;
+        Ham[k][i] += Ham[k][j] * fSinBuffer * conj(fExpBuffer);
 
-        fHms[k][j] *= fCosBuffer;
-        fHms[k][j] -= fHmsBufferC * fSinBuffer * fExpBuffer;
+        Ham[k][j] *= fCosBuffer;
+        Ham[k][j] -= fHmsBufferC * fSinBuffer * fExpBuffer;
       }
 
       // Middle row and column
       for(int k=i+1; k<j; k++){
-        fHmsBufferC = fHms[k][j];
+        fHmsBufferC = Ham[k][j];
 
-        fHms[k][j] *= fCosBuffer;
-        fHms[k][j] -= conj(fHms[i][k]) * fSinBuffer * fExpBuffer;
+        Ham[k][j] *= fCosBuffer;
+        Ham[k][j] -= conj(Ham[i][k]) * fSinBuffer * fExpBuffer;
 
-        fHms[i][k] *= fCosBuffer;
-        fHms[i][k] += fSinBuffer * fExpBuffer * conj(fHmsBufferC);
+        Ham[i][k] *= fCosBuffer;
+        Ham[i][k] += fSinBuffer * fExpBuffer * conj(fHmsBufferC);
       }
 
       // Nodes ij
-      fHmsBufferC = fHms[i][i];
-      fHmsBufferD = real(fHms[j][j]);
+      fHmsBufferC = Ham[i][i];
+      fHmsBufferD = real(Ham[j][j]);
 
-      fHms[i][i] *= fCosBuffer * fCosBuffer;
-      fHms[i][i] += 2 * fSinBuffer * fCosBuffer * real(fHms[i][j] * conj(fExpBuffer));
-      fHms[i][i] += fSinBuffer * fHms[j][j] * fSinBuffer;
+      Ham[i][i] *= fCosBuffer * fCosBuffer;
+      Ham[i][i] += 2 * fSinBuffer * fCosBuffer * real(Ham[i][j] * conj(fExpBuffer));
+      Ham[i][i] += fSinBuffer * Ham[j][j] * fSinBuffer;
 
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
-      fHms[j][j] += fSinBuffer * fHmsBufferC * fSinBuffer;
-      fHms[j][j] -= 2 * fSinBuffer * fCosBuffer * real(fHms[i][j] * conj(fExpBuffer));
+      Ham[j][j] *= fCosBuffer * fCosBuffer;
+      Ham[j][j] += fSinBuffer * fHmsBufferC * fSinBuffer;
+      Ham[j][j] -= 2 * fSinBuffer * fCosBuffer * real(Ham[i][j] * conj(fExpBuffer));
 
-      fHms[i][j] -= 2 * fSinBuffer * real(fHms[i][j] * conj(fExpBuffer)) * fSinBuffer * fExpBuffer;
-      fHms[i][j] += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC) * fExpBuffer;
+      Ham[i][j] -= 2 * fSinBuffer * real(Ham[i][j] * conj(fExpBuffer)) * fSinBuffer * fExpBuffer;
+      Ham[i][j] += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC) * fExpBuffer;
 
     }
     // First rotation on j (No top columns)
     else{
       // Middle rows and columns
       for(int k=i+1; k<j; k++){
-        fHms[k][j] = -conj(fHms[i][k]) * fSinBuffer * fExpBuffer;
+        Ham[k][j] = -conj(Ham[i][k]) * fSinBuffer * fExpBuffer;
 
-        fHms[i][k] *= fCosBuffer;
+        Ham[i][k] *= fCosBuffer;
       }
 
       // Nodes ij
-      fHmsBufferD = real(fHms[i][i]);
+      fHmsBufferD = real(Ham[i][i]);
 
-      fHms[i][j] = fSinBuffer * fCosBuffer * (fHms[j][j] - fHmsBufferD) * fExpBuffer;
+      Ham[i][j] = fSinBuffer * fCosBuffer * (Ham[j][j] - fHmsBufferD) * fExpBuffer;
 
-      fHms[i][i] *= fCosBuffer * fCosBuffer;
-      fHms[i][i] += fSinBuffer * fHms[j][j] * fSinBuffer;
+      Ham[i][i] *= fCosBuffer * fCosBuffer;
+      Ham[i][i] += fSinBuffer * Ham[j][j] * fSinBuffer;
 
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
-      fHms[j][j] += fSinBuffer * fHmsBufferD * fSinBuffer;
+      Ham[j][j] *= fCosBuffer * fCosBuffer;
+      Ham[j][j] += fSinBuffer * fHmsBufferD * fSinBuffer;
     }
 
   }
@@ -990,39 +990,39 @@ void PMNS_Base::RotateH(int i,int j){
     if(i>0){
       // Top columns
       for(int k=0; k<i; k++){
-        fHmsBufferC = fHms[k][i];
+        fHmsBufferC = Ham[k][i];
 
-        fHms[k][i] *= fCosBuffer;
-        fHms[k][i] += fHms[k][j] * fSinBuffer;
+        Ham[k][i] *= fCosBuffer;
+        Ham[k][i] += Ham[k][j] * fSinBuffer;
 
-        fHms[k][j] *= fCosBuffer;
-        fHms[k][j] -= fHmsBufferC * fSinBuffer;
+        Ham[k][j] *= fCosBuffer;
+        Ham[k][j] -= fHmsBufferC * fSinBuffer;
       }
 
       // Nodes ij
-      fHmsBufferC = fHms[i][i];
-      fHmsBufferD = real(fHms[j][j]);
+      fHmsBufferC = Ham[i][i];
+      fHmsBufferD = real(Ham[j][j]);
 
-      fHms[i][i] *= fCosBuffer * fCosBuffer;
-      fHms[i][i] += 2 * fSinBuffer * fCosBuffer * real(fHms[i][j]);
-      fHms[i][i] += fSinBuffer * fHms[j][j] * fSinBuffer;
+      Ham[i][i] *= fCosBuffer * fCosBuffer;
+      Ham[i][i] += 2 * fSinBuffer * fCosBuffer * real(Ham[i][j]);
+      Ham[i][i] += fSinBuffer * Ham[j][j] * fSinBuffer;
 
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
-      fHms[j][j] += fSinBuffer * fHmsBufferC * fSinBuffer;
-      fHms[j][j] -= 2 * fSinBuffer * fCosBuffer * real(fHms[i][j]);
+      Ham[j][j] *= fCosBuffer * fCosBuffer;
+      Ham[j][j] += fSinBuffer * fHmsBufferC * fSinBuffer;
+      Ham[j][j] -= 2 * fSinBuffer * fCosBuffer * real(Ham[i][j]);
 
-      fHms[i][j] -= 2 * fSinBuffer * real(fHms[i][j]) * fSinBuffer;
-      fHms[i][j] += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC);
+      Ham[i][j] -= 2 * fSinBuffer * real(Ham[i][j]) * fSinBuffer;
+      Ham[i][j] += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC);
 
     }
     // First rotation (theta12)
     else{
 
-      fHms[i][j] = fSinBuffer * fCosBuffer * fHms[j][j];
+      Ham[i][j] = fSinBuffer * fCosBuffer * Ham[j][j];
 
-      fHms[i][i] = fSinBuffer * fHms[j][j] * fSinBuffer;
+      Ham[i][i] = fSinBuffer * Ham[j][j] * fSinBuffer;
 
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
+      Ham[j][j] *= fCosBuffer * fCosBuffer;
 
     }
   }
@@ -1059,7 +1059,7 @@ void PMNS_Base::BuildHms()
     }
     // Rotate j neutrinos
     for(int i=0; i<j; i++){
-      RotateH(i,j);
+      RotateH(i,j,fHms);
     }
   }
 

--- a/PMNS_Base.cxx
+++ b/PMNS_Base.cxx
@@ -906,6 +906,7 @@ std::vector<complexD> PMNS_Base::GetMassEigenstate(int mi){
 /// and it speeds up computation by skipping null terms
 ///
 /// @param i,j - the indices of the rotation ij
+/// @param Ham - the Hamiltonian to be rotated
 ///
 void PMNS_Base::RotateH(int i,int j,std::vector< std::vector<complexD> >& Ham){
 

--- a/PMNS_Base.h
+++ b/PMNS_Base.h
@@ -155,7 +155,7 @@ namespace OscProb {
 
 
     // Building and solving
-    virtual void RotateH(int i,int j); ///< Rotate the Hamiltonian by theta_ij and delta_ij
+    virtual void RotateH(int i,int j,std::vector< std::vector<complexD> >& Ham); ///< Rotate the Hamiltonian by theta_ij and delta_ij
     virtual void RotateState(int i,int j); ///< Rotate the neutrino state by theta_ij and delta_ij
 
     virtual void BuildHms();           ///< Build the matrix of masses squared.

--- a/PMNS_Decay.cxx
+++ b/PMNS_Decay.cxx
@@ -3,8 +3,8 @@
 // Implementation of oscillations of neutrinos in matter in a
 // three-neutrino framework with Neutrino Decay in the 3rd state. 
 //
-// This class expands the PMNS_Fast class including the decay of the third mass// state of the neutrino through a decay constant alpha3=m3/tau3 (eV^2), where 
-// m3 is the mass in the restframe and tau3 is the lifetime in the restframe.
+// This class expands the PMNS_Fast class including the decay of the second and third mass// state of the neutrino through a decay constant alpha_i=m_i/tau_i (eV^2), where 
+// m_i is the mass in the restframe and tau_i is the lifetime in the restframe.
 //
 // Diagonalization of the matrix is done using the Eigen library. 
 //
@@ -66,11 +66,21 @@ if(alpha3<0){
 }
 
 fBuiltHms *= (falpha[2] == alpha3);
-
-
- falpha[0]=0;
- falpha[1]=0;
  falpha[2] = alpha3;
+
+}
+//......................................................................                                              
+///     Setting Alpha2 parameter, it must be possitive, and units are eV^2 .
+///     Alpha2=m2/tau2, mass and lifetime of the second state in the restframe
+void PMNS_Decay::SetAlpha2(double alpha2)
+{
+  if(alpha2<0){
+    cout << "Alpha2 must be positive" << endl;
+    return;
+  }
+
+  fBuiltHms *= (falpha[1] == alpha2);
+  falpha[1] = alpha2;
 
 }
 
@@ -106,135 +116,11 @@ double PMNS_Decay::GetAlpha3()
 {
 return falpha[2];
 }
-///Build the Hamiltonian and rotate it
-void PMNS_Decay::RotateH(int i,int j){
-
-  // Do nothing if angle is zero
-  if(fTheta[i][j]==0) return;
-
-  double fSinBuffer = sin(fTheta[i][j]);
-  double fCosBuffer = cos(fTheta[i][j]);
-
-  double  fHmsBufferD;
-  complexD fHmsBufferC;
-
-  // With Delta
-  if(i+1<j){
-    complexD fExpBuffer;
-    if(fIsNuBar==true){
-      fExpBuffer = complexD(cos(-fDelta[i][j]), -sin(-fDelta[i][j]));
-    }
-    else{
-      fExpBuffer = complexD(cos(fDelta[i][j]), -sin(fDelta[i][j]));
-    }
-
-    // General case
-    if(i>0){
-      // Top columns
-      for(int k=0; k<i; k++){
-        fHmsBufferC = fHms[k][i];
-
-        fHms[k][i] *= fCosBuffer;
-        fHms[k][i] += fHms[k][j] * fSinBuffer * conj(fExpBuffer);
-
-        fHms[k][j] *= fCosBuffer;
-        fHms[k][j] -= fHmsBufferC * fSinBuffer * fExpBuffer;
-      }
-
-      // Middle row and column
-      for(int k=i+1; k<j; k++){
-        fHmsBufferC = fHms[k][j];
-
-        fHms[k][j] *= fCosBuffer;
-        fHms[k][j] -= conj(fHms[i][k]) * fSinBuffer * fExpBuffer;
-
-        fHms[i][k] *= fCosBuffer;
-        fHms[i][k] += fSinBuffer * fExpBuffer * conj(fHmsBufferC);
-      }
-
-      // Nodes ij
-      fHmsBufferC = fHms[i][i];
-      fHmsBufferD = real(fHms[j][j]);
-
-      fHms[i][i] *= fCosBuffer * fCosBuffer;
-      fHms[i][i] += 2 * fSinBuffer * fCosBuffer * real(fHms[i][j] * conj(fExpBuffer));
-      fHms[i][i] += fSinBuffer * fHms[j][j] * fSinBuffer;
-
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
-      fHms[j][j] += fSinBuffer * fHmsBufferC * fSinBuffer;
-      fHms[j][j] -= 2 * fSinBuffer * fCosBuffer * real(fHms[i][j] * conj(fExpBuffer));
-
-      fHms[i][j] -= 2 * fSinBuffer * real(fHms[i][j] * conj(fExpBuffer)) * fSinBuffer * fExpBuffer;
-      fHms[i][j] += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC) * fExpBuffer;
-
-    }
-    // First rotation on j (No top columns)
-    else{
-      // Middle rows and columns
-      for(int k=i+1; k<j; k++){
-        fHms[k][j] = -conj(fHms[i][k]) * fSinBuffer * fExpBuffer;
-
-        fHms[i][k] *= fCosBuffer;
-      }
-
-      // Nodes ij
-      fHmsBufferD = real(fHms[i][i]);
-
-      fHms[i][j] = fSinBuffer * fCosBuffer * (fHms[j][j] - fHmsBufferD) * fExpBuffer;
-
-      fHms[i][i] *= fCosBuffer * fCosBuffer;
-      fHms[i][i] += fSinBuffer * fHms[j][j] * fSinBuffer;
-
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
-      fHms[j][j] += fSinBuffer * fHmsBufferD * fSinBuffer;
-    }
-
-  }
-  // Without Delta (No middle rows or columns: j = i+1)
-  else{
-    // General case
-    if(i>0){
-      // Top columns
-      for(int k=0; k<i; k++){
-        fHmsBufferC = fHms[k][i];
-
-        fHms[k][i] *= fCosBuffer;
-        fHms[k][i] += fHms[k][j] * fSinBuffer;
-
-        fHms[k][j] *= fCosBuffer;
-        fHms[k][j] -= fHmsBufferC * fSinBuffer;
-      }
-
-      // Nodes ij
-      fHmsBufferC = fHms[i][i];
-      fHmsBufferD = real(fHms[j][j]);
-
-      fHms[i][i] *= fCosBuffer * fCosBuffer;
-      fHms[i][i] += 2 * fSinBuffer * fCosBuffer * real(fHms[i][j]);
-      fHms[i][i] += fSinBuffer * fHms[j][j] * fSinBuffer;
-
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
-      fHms[j][j] += fSinBuffer * fHmsBufferC * fSinBuffer;
-      fHms[j][j] -= 2 * fSinBuffer * fCosBuffer * real(fHms[i][j]);
-
-      fHms[i][j] -= 2 * fSinBuffer * real(fHms[i][j]) * fSinBuffer;
-      fHms[i][j] += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC);
-
-    }
-    // First rotation (theta12)
-    else{
-
-      fHms[i][j] = fSinBuffer * fCosBuffer * fHms[j][j];
-
-      fHms[i][i] = fSinBuffer * fHms[j][j] * fSinBuffer;
-
-      fHms[j][j] *= fCosBuffer * fCosBuffer;
-
-    }
-  }
-
+/// Get alpha2
+double PMNS_Decay::GetAlpha2()
+{
+  return falpha[1];
 }
-
 
 void PMNS_Decay::RotateHd(int i,int j){
 
@@ -250,13 +136,9 @@ void PMNS_Decay::RotateHd(int i,int j){
   // With Delta
   if(i+1<j){
     complexD fExpBuffer;
-    if(fIsNuBar==true){
-      fExpBuffer = complexD(cos(-fDelta[i][j]), -sin(-fDelta[i][j]));
-}
-    else{
       fExpBuffer = complexD(cos(fDelta[i][j]), -sin(fDelta[i][j]));
     
-}
+
 
     // General case
     if(i>0){
@@ -378,69 +260,68 @@ void PMNS_Decay::BuildHam()
   
   ///Reset everything
    for(int i=0; i<fNumNus; i++){
-   for(int j=0; j<fNumNus; j++){
-	   fHms[i][j]= 0;
-	   }
+     for(int j=0; j<fNumNus; j++){
+       fHms[i][j]= 0;
+     }
    }
-  for(int j=0; j<fNumNus; j++){
-    // Set mass splitting
-    fHms[j][j] = fDm[j];
-    // Reset off-diagonal elements
-    for(int i=0; i<j; i++){
-      fHms[i][j] = 0;
-    }
- 
-    //Rotate j neutrinos
-    for(int i=0; i<j; i++){
-      RotateH(i,j);
-    }
-  }
-  
+   for(int j=0; j<fNumNus; j++){
+     // Set mass splitting
+     fHms[j][j] = fDm[j]; 
+     //Rotate j neutrinos
+     for(int i=0; i<j; i++){
+       RotateH(i,j);
+     }
+   }
+  //Taking care of antineutrinos delta-> -delta and filling the upper triangle
+  // because final hamiltonian will be non-hermitian.
    for(int i=0; i<fNumNus; i++){
-   for(int j=i+1; j<fNumNus; j++){
-	   fHms[j][i]= conj(fHms[i][j]);
-	   }
+     for(int j=i+1; j<fNumNus; j++){
+       if(fIsNuBar){
+	 fHms[i][j]=conj(fHms[i][j]);
+       }           
+       fHms[j][i]= conj(fHms[i][j]);
+     }
    }
   
 
   ///Introduction of the alpha3
   ///Reset everything
    for(int i=0; i<fNumNus; i++){
-   for(int j=0; j<fNumNus; j++){
-	   fHd[i][j]= 0;
-	   }
+     for(int j=0; j<fNumNus; j++){
+       fHd[i][j]= 0;
+     }
    }
   
    for(int j=0; j<fNumNus; j++){
 	   
     // Set alpha
-    fHd[j][j] = falpha[j];
+     fHd[j][j] = falpha[j];
     
-    // Reset off-diagonal elements
-    for(int i=0; i<j; i++){
-      fHd[i][j] = 0;
-    }
- 
+     
     // Rotate j neutrinos
-    for(int i=0; i<j; i++){
-      RotateHd(i,j);
-    }
-  }
-  
+     for(int i=0; i<j; i++){
+       RotateHd(i,j);
+     }
+   }
+   //Taking care of antineutrinos delta-> -delta and filling the upper triangle
+   // because final hamiltonian will be non-hermitian.
    for(int i=0; i<fNumNus; i++){
-   for(int j=i+1; j<fNumNus; j++){
-	   fHd[j][i]= conj(fHd[i][j]);
-	   }
+     for(int j=i+1; j<fNumNus; j++){
+       if(fIsNuBar){
+	 fHd[i][j]=conj(fHd[i][j]);
+       }
+       fHd[j][i]= conj(fHd[i][j]);
+     }
    }
   
 
-  const   complex<double> numi(0.0,1.0);  
-  ///Construct the total Hms+Hd
-  for(int j=0; j<fNumNus; j++){
-	for(int i=0; i<fNumNus; i++){
-		fHt[i][j]=fHms[i][j]-numi*fHd[i][j];
-  }
-}  
+   const   complex<double> numi(0.0,1.0);  
+   ///Construct the total Hms+Hd
+   for(int j=0; j<fNumNus; j++){
+     for(int i=0; i<fNumNus; i++){
+       fHt[i][j]=fHms[i][j]-numi*fHd[i][j];
+     }
+   }  
  
  
  
@@ -534,20 +415,6 @@ void PMNS_Decay::SolveHam()
 
 }
 
-bool PMNS_Decay::CheckProb(int flvi)
-{
-	double controler=0;
-for( int i=0; i<fNumNus; i++){
-	controler+=Prob(flvi,i);
-}
-
-if(controler <= 1.0005)
-{
-	return true;
-	}
-else{
-	return false;}
-}
 //.....................................................................
 ///
 /// Set the eigensystem to the analytic solution in vacuum.
@@ -570,19 +437,15 @@ void PMNS_Decay::PropagatePath(NuPath p)
     double arg = fEval[i] * LengthIneV;
     double argI = fEvalI[i] * LengthIneV;
     std::complex<double> numi=std::complex<double>(0,1.0);
-   // fPhases[i] = complexD(cos(arg)*exp(argI), -sin(arg)*exp(argI));
-   fPhases[i] = exp(-numi*(arg+numi*argI));
+    // fPhases[i] = complexD(cos(arg)*exp(argI), -sin(arg)*exp(argI));
+    fPhases[i] = exp(-numi*(arg+numi*argI));
    
    
-}
+  }
   for(int i=0;i<fNumNus;i++){
     fBuffer[i] = 0;
     for(int j=0;j<fNumNus;j++){
-		//if(falpha[2]==0){
       fBuffer[i] += fEvecinv[i][j] * fNuState[j];
-        //                }
-     // else{
-	//	  fBuffer[i] += conj(fEvec[j][i]) * fNuState[j];
     }
     fBuffer[i] *= fPhases[i];
   }
@@ -593,11 +456,7 @@ void PMNS_Decay::PropagatePath(NuPath p)
     for(int j=0;j<fNumNus;j++){
       fNuState[i] +=  fEvec[i][j] * fBuffer[j];
       
-    }
-    
-	
-		
-		
+    }		
 	
   }
 

--- a/PMNS_Decay.cxx
+++ b/PMNS_Decay.cxx
@@ -26,10 +26,15 @@ using namespace OscProb;
 /// This class is restricted to 3 neutrino flavours.
 ///
 PMNS_Decay::PMNS_Decay() : PMNS_Base(), fHam() {
-	falpha    = vector<double>(fNumNus, 0);
-	fEvalI = vector<double>(fNumNus, 0); /////
-	fEvecinv = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero)); /////
-	fHd     = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero));	 
+	falpha         = vector<double>(fNumNus, 0);
+	fEvalI         = vector<double>(fNumNus, 0); 
+	fEvecinv       = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero));
+	fEvalEigen     = vector<complexD>(fNumNus, 0);
+	fEvecEigen     = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero));
+	fEvecEigeninv  = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero));
+	fHd            = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero));	 
+	fHam           = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero));
+	fHt            = vector< vector<complexD> >(fNumNus, vector<complexD>(fNumNus,zero));
 	}
 
 //......................................................................
@@ -263,13 +268,8 @@ void PMNS_Decay::SolveHam()
 
   UpdateHam();
 
-
-  complexD fEvalEigen[3];
-  complexD fEvecEigen[3][3];
-  complexD fEvecEigeninv[3][3];
   // Solve Hamiltonian for eigensystem using the Eigen library method 
   complexsolver(fHam,fEvecEigen,fEvecEigeninv,fEvalEigen);
-
 
 
   // Fill fEval and fEvec vectors from Eigen arrays  
@@ -311,7 +311,6 @@ void PMNS_Decay::PropagatePath(NuPath p)
     double arg = fEval[i] * LengthIneV;
     double argI = fEvalI[i] * LengthIneV;
     std::complex<double> numi=std::complex<double>(0,1.0);
-    // fPhases[i] = complexD(cos(arg)*exp(argI), -sin(arg)*exp(argI));
     fPhases[i] = exp(-numi*(arg+numi*argI));
    
    

--- a/PMNS_Decay.h
+++ b/PMNS_Decay.h
@@ -35,15 +35,14 @@ namespace OscProb {
     std::vector<double>                  fEvalI;
     
     virtual void SetAlpha3(double alpha3);
+    virtual void SetAlpha2(double alpha2);
     virtual double GetAlpha3();
-    virtual bool CheckProb(int flvi);
+    virtual double GetAlpha2();
     virtual void SetIsNuBar(bool isNuBar);
     
   protected:
     virtual void BuildHam();
    
- //   virtual void BuildHt();
-    virtual void RotateH(int i, int j);
     virtual void RotateHd(int i, int j);
     /// Build the full Hamiltonian
     virtual void UpdateHam();

--- a/PMNS_Decay.h
+++ b/PMNS_Decay.h
@@ -43,7 +43,6 @@ namespace OscProb {
   protected:
     virtual void BuildHam();
    
-    virtual void RotateHd(int i, int j);
     /// Build the full Hamiltonian
     virtual void UpdateHam();
    
@@ -55,9 +54,9 @@ namespace OscProb {
     virtual void PropagatePath(OscProb::NuPath p);    ///< Propagate neutrino through a single path
     
     
-    complexD fHam[3][3]; ///< The full hamiltonian
-    complexD fHd[3][3];
-    complexD fHt[3][3];
+    std::vector< std::vector<complexD> > fHd; //Decay hamiltonian
+    complexD fHam[3][3]; //Final hamiltonian 
+    complexD fHt[3][3]; //Standard+Decay hamiltonian
     
   };
 

--- a/PMNS_Decay.h
+++ b/PMNS_Decay.h
@@ -55,9 +55,12 @@ namespace OscProb {
     
     
     std::vector< std::vector<complexD> > fHd; //Decay hamiltonian
-    complexD fHam[3][3]; //Final hamiltonian 
-    complexD fHt[3][3]; //Standard+Decay hamiltonian
-    
+    std::vector< std::vector<complexD> > fHam;  //Final hamiltonian 
+    std::vector< std::vector<complexD> > fHt;  //Standard+Decay hamiltonian
+   
+    std::vector< complexD > fEvalEigen;
+    std::vector< std::vector<complexD> > fEvecEigen;
+    std::vector< std::vector<complexD> > fEvecEigeninv;    
   };
 
 }

--- a/PMNS_Decay.h
+++ b/PMNS_Decay.h
@@ -43,6 +43,7 @@ namespace OscProb {
     virtual void BuildHam();
    
  //   virtual void BuildHt();
+    virtual void RotateH(int i, int j);
     virtual void RotateHd(int i, int j);
     /// Build the full Hamiltonian
     virtual void UpdateHam();

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Available classes are:
 - **PMNS_Sterile:** Oscillations with any number of neutrinos
 - **PMNS_NSI:** Oscillations with 3 flavours including Non-Standard Interactions
 - **PMNS_Deco:** Oscillations with 3 flavours including a simple decoherence model
-- **PMNS_Decay:** Oscillations with 3 flavours including neutrino decay of the neutrino mass state \nu_3. [Requires external library Eigen3, see the instructions below.]
+- **PMNS_Decay:** Oscillations with 3 flavours including neutrino decays of the second and third neutrino mass states \nu_2 and \nu_3. [Requires external library Eigen3, see the instructions below.]
 
 A few example macros on how to use OscProb are available in a tutorial directory.
 

--- a/utils/complexsolver.h
+++ b/utils/complexsolver.h
@@ -1,23 +1,26 @@
 #include <iostream>
 #include "Eigenvalues"
+#include <complex>
+#include <vector>
 
 using namespace Eigen;
 using namespace std;
 
-void complexsolver(std::complex<double> A[3][3], std::complex<double> Q[3][3], std::complex<double> Qinv[3][3], std::complex<double> w[3])
-{
 
-  Matrix3cd l;
-  Matrix3cd evc, evcinv;
-  Vector3cd evl;
+void complexsolver(std::vector< std::vector<complexD> > A, std::vector< std::vector<complexD> >& Q, std::vector< std::vector<complexD> >& Qinv, std::vector< complexD >& w)  
+{
+  int size=w.size();
+  MatrixXcd l(size,size);
+  MatrixXcd evc(size,size), evcinv(size,size);
+  VectorXcd evl(size);
   
-  for(int n=0; n<3; n++){
-    for(int m=0; m<3; m++){
+  for(int n=0; n<size; n++){
+    for(int m=0; m<size; m++){
       l(n,m)=A[n][m];
     } 
   }  
                   
-  ComplexEigenSolver<Matrix3cd> eigensolver;
+  ComplexEigenSolver<MatrixXcd> eigensolver;
   eigensolver.compute(l);
  
   if(eigensolver.info() != Success){ 
@@ -28,13 +31,13 @@ void complexsolver(std::complex<double> A[3][3], std::complex<double> Q[3][3], s
   evl = eigensolver.eigenvalues();
   evc= eigensolver.eigenvectors();
   evcinv=evc.inverse();
-  for(int n=0; n<3; n++){
-    for(int m=0; m<3; m++){
+  for(int n=0; n<size; n++){
+    for(int m=0; m<size; m++){
       Q[n][m] = evc(n,m);
       Qinv[n][m]= evcinv(n,m);
     } 
   }  
-  for(int t=0; t<3; t++){
+  for(int t=0; t<size; t++){
     w[t] = evl(t);
   }
               


### PR DESCRIPTION
When changing multiple times between nu and nubar in PMNS_Decay a bug happens (which I didn't detect because I didn't try such a thing in my tests). I solved it by handling delta_cp in a different way (because for the decay case, the matrix is non-hermitian and you cannot just conjugate the matrix in the case they are antineutrinos, so the delta sign change is handled in the rotations in the case they are antineutrinos).