### PR TITLE
Improve decay class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GSL_INCS := $(shell gsl-config --cflags)
 GSL_LIBS := $(shell gsl-config --libs)
 
 #Eigen library
-Eigen_INCS = ${CURDIR}/eigen/Eigen
+Eigen_INCS = ${CURDIR}/eigen
 
 INCDIRS = -I$(CURDIR) -I$(CURDIR)/inc $(GSL_INCS) -I$(Eigen_INCS)
 
@@ -80,8 +80,9 @@ $(PREMINC): $(PREMDIR) $(PREMFILE) $(MODEL3DDIR) $(PREM3DFILE)
 	@echo "const std::string PREM3D_DEFAULT = \"$(PREM3DFILE)\";" >> $@
 
 test: $(TARGET_LIB)
-	@cd test && root -l -b -q ../tutorial/LoadOscProb.C ../tutorial/SetNiceStyle.C TestMethods.C
-	@cd test && root -l -b -q ../tutorial/LoadOscProb.C ../tutorial/SetNiceStyle.C CheckProbs.C
+	@cd test && root -l -b -q ../tutorial/LoadOscProb.C TestMethods.C
+	@cd test && root -l -b -q ../tutorial/LoadOscProb.C CheckProbs.C
+	@cd test && root -l -b -q ../tutorial/LoadOscProb.C StressTest.C
 
 clean: $(CLEANDIRS)
 	@echo "  Cleaning $(PACKAGE)..."

--- a/inc/PMNS_Decay.h
+++ b/inc/PMNS_Decay.h
@@ -50,16 +50,12 @@ namespace OscProb {
     ///Propagation with D
     virtual void PropagatePath(NuPath p);    ///< Propagate neutrino through a single path
     
-    
+
     matrixC fHd;  //Decay hamiltonian
     matrixC fHam; //Final hamiltonian
-    matrixC fHt;  //Standard+Decay hamiltonian
    
     //Set Alpha 3
     vectorD falpha;
-
-    vectorC fEvalEigen;
-    matrixC fEvecinv;
 
   };
 

--- a/inc/PMNS_Decay.h
+++ b/inc/PMNS_Decay.h
@@ -30,10 +30,6 @@ namespace OscProb {
     
     /// Set both mass-splittings at once
     virtual void SetDeltaMsqrs(double dm21, double dm32);
-    //Set Alpha 3
-    vectorD falpha;
-    matrixC fEvecinv;
-    vectorD fEvalI;
     
     virtual void SetAlpha3(double alpha3);
     virtual void SetAlpha2(double alpha2);
@@ -59,9 +55,12 @@ namespace OscProb {
     matrixC fHam; //Final hamiltonian
     matrixC fHt;  //Standard+Decay hamiltonian
    
+    //Set Alpha 3
+    vectorD falpha;
+
     vectorC fEvalEigen;
-    matrixC fEvecEigen;
-    matrixC fEvecEigeninv;
+    matrixC fEvecinv;
+
   };
 
 }

--- a/inc/PMNS_Decay.h
+++ b/inc/PMNS_Decay.h
@@ -14,6 +14,9 @@
 
 #ifndef PMNS_Decay_H
 #define PMNS_Decay_H
+
+#include <Eigen/Core>
+
 #include "PMNS_Base.h"
 
 namespace OscProb {
@@ -51,8 +54,8 @@ namespace OscProb {
     virtual void PropagatePath(NuPath p);    ///< Propagate neutrino through a single path
     
 
-    matrixC fHd;  //Decay hamiltonian
-    matrixC fHam; //Final hamiltonian
+    matrixC fHd;           //Decay hamiltonian
+    Eigen::MatrixXcd fHam; //Final hamiltonian
    
     //Set Alpha 3
     vectorD falpha;

--- a/inc/PMNS_Decay.h
+++ b/inc/PMNS_Decay.h
@@ -1,16 +1,12 @@
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 /// \class OscProb::PMNS_Decay
 ///
-/// \brief Implementation of neutrino decay of the third mass state 
+/// \brief Implementation of neutrino decay of the third mass state
 ///        \f$\nu_3\f$ with oscillations of neutrinos in matter in a
 ///        three-neutrino framework.
 ///
-///                               
-///......................................................................
-/// 
-///
 /// \author Victor Carretero - vcarretero@km3net.de
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 
 #ifndef PMNS_Decay_H
 #define PMNS_Decay_H
@@ -27,38 +23,38 @@ namespace OscProb {
 
     PMNS_Decay();          ///< Constructor
     virtual ~PMNS_Decay(); ///< Destructor
-    
+
     /// Set the all mixing parameters at once
     virtual void SetMix(double th12, double th23, double th13, double deltacp);
-    
+
     /// Set both mass-splittings at once
     virtual void SetDeltaMsqrs(double dm21, double dm32);
-    
+
     virtual void SetAlpha3(double alpha3);
     virtual void SetAlpha2(double alpha2);
     virtual double GetAlpha3();
     virtual double GetAlpha2();
     virtual void SetIsNuBar(bool isNuBar);
-    
+
   protected:
-    virtual void BuildHam();
-   
+
+    /// Build the Hms Hamiltonian
+    virtual void BuildHms();
+
     /// Build the full Hamiltonian
     virtual void UpdateHam();
-   
 
-    /// Solve the full Hamiltonian for eigenvectors and eigenvalues
+    /// Solve the full Hamiltonian for eigenvalues
     virtual void SolveHam();
-    
-    ///Propagation with D
-    virtual void PropagatePath(NuPath p);    ///< Propagate neutrino through a single path
-    
 
-    matrixC fHd;           //Decay hamiltonian
-    Eigen::MatrixXcd fHam; //Final hamiltonian
-   
-    //Set Alpha 3
-    vectorD falpha;
+    /// Propagation with Decay
+    virtual void PropagatePath(NuPath p);
+
+
+    matrixC fHd;           ///< Decay hamiltonian
+    Eigen::MatrixXcd fHam; ///< Final hamiltonian
+
+    vectorD fAlpha; ///< alpha parameters
 
   };
 

--- a/inc/complexsolver.h
+++ b/inc/complexsolver.h
@@ -1,9 +1,11 @@
 #ifndef COMPLEXSOLVER_H
 #define COMPLEXSOLVER_H
 
+#include <Eigen/Core>
+
 #include "Definitions.h"
 
-void complexsolver(OscProb::matrixC  A,
+void complexsolver(const Eigen::MatrixXcd& A,
                    OscProb::vectorD& w);
 
 #endif

--- a/inc/complexsolver.h
+++ b/inc/complexsolver.h
@@ -1,13 +1,9 @@
 #ifndef COMPLEXSOLVER_H
 #define COMPLEXSOLVER_H
 
-#include "Eigenvalues"
-
 #include "Definitions.h"
 
 void complexsolver(OscProb::matrixC  A,
-                   OscProb::matrixC& Q,
-                   OscProb::matrixC& Qinv,
-                   OscProb::vectorC& w);
+                   OscProb::vectorD& w);
 
 #endif

--- a/src/PMNS_Decay.cxx
+++ b/src/PMNS_Decay.cxx
@@ -1,30 +1,30 @@
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 ///
 /// Implementation of oscillations of neutrinos in matter in a
-/// three-neutrino framework with Neutrino Decay in the 3rd state. 
+/// three-neutrino framework with Neutrino Decay in the 3rd state.
 ///
 /// This class expands the PMNS_Fast class including the decay of the 
 /// second and third mass state of the neutrino through a decay constant
 /// alpha_i=m_i/tau_i (eV^2), where m_i is the mass in the restframe and
 /// tau_i is the lifetime in the restframe.
 ///
-/// Diagonalization of the matrix is done using the Eigen library. 
+/// Diagonalization of the matrix is done using the Eigen library.
 ///
-/// \author Victor Carretero - vcarretero\@km3net.de  
+/// \author Victor Carretero - vcarretero\@km3net.de
 /// \author Joao Coelho - jcoelho\@apc.in2p3.fr
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 
 #include <iostream>
 
-#include "complexsolver.h"
 #include <unsupported/Eigen/MatrixFunctions>
 
+#include "complexsolver.h"
 #include "PMNS_Decay.h"
 
 using namespace OscProb;
 using namespace std;
 
-//......................................................................
+//.............................................................................
 ///
 /// Constructor. \sa PMNS_Base::PMNS_Base
 ///
@@ -32,75 +32,92 @@ using namespace std;
 ///
 PMNS_Decay::PMNS_Decay() : PMNS_Base() {
 
-  falpha         = vectorD(fNumNus, 0);
+  fAlpha         = vectorD(fNumNus, 0);
   fHam           = Eigen::MatrixXcd(fNumNus, fNumNus);
   fHd            = matrixC(fNumNus, vectorC(fNumNus,zero));
 
 }
 
-//......................................................................
+//.............................................................................
 ///
 /// Nothing to clean.
 ///
 PMNS_Decay::~PMNS_Decay(){}
 
-//......................................................................
+//.............................................................................
 ///
 /// Set all mixing parameters at once.
+///
 /// @param th12    - The value of the mixing angle theta_12
 /// @param th23    - The value of the mixing angle theta_23
 /// @param th13    - The value of the mixing angle theta_13
 /// @param deltacp - The value of the CP phase delta_13
 ///
-void PMNS_Decay::SetMix(double th12, double th23, double th13, double deltacp) 
+void PMNS_Decay::SetMix(double th12, double th23, double th13, double deltacp)
 {
+
   SetAngle(1,2, th12);
   SetAngle(1,3, th13);
   SetAngle(2,3, th23);
   SetDelta(1,3, deltacp);
+
 }
 
-//......................................................................                                                       
-///     Setting Alpha3 parameter, it must be possitive, and units are eV^2 .
-///     Alpha3=m3/tau3, mass and lifetime of the third state in the restframe 
-void PMNS_Decay::SetAlpha3(double alpha3) 
+//.............................................................................
+///
+/// Setting Alpha3 parameter, it must be possitive, and units are eV^2.
+///
+/// @param alpha3 = m3/tau3, mass and lifetime of the 3rd state in the restframe
+///
+void PMNS_Decay::SetAlpha3(double alpha3)
 {
+
   if(alpha3<0){
     cerr << "WARNING: Alpha3 must be positive. Doing nothing." << endl;
     return;
   }
 
-  fBuiltHms *= (falpha[2] == alpha3);
-  falpha[2] = alpha3;
+  fBuiltHms *= (fAlpha[2] == alpha3);
+  fAlpha[2] = alpha3;
+
 }
 
-//......................................................................                                              
-///     Setting Alpha2 parameter, it must be possitive, and units are eV^2 .
-///     Alpha2=m2/tau2, mass and lifetime of the second state in the restframe
+//.............................................................................
+///
+/// Setting Alpha2 parameter, it must be possitive, and units are eV^2.
+///
+/// @param alpha2 = m2/tau2, mass and lifetime of the 2nd state in the restframe
+///
 void PMNS_Decay::SetAlpha2(double alpha2)
 {
+
   if(alpha2<0){
     cerr << "WARNING: Alpha2 must be positive. Doing nothing." << endl;
     return;
   }
 
-  fBuiltHms *= (falpha[1] == alpha2);
-  falpha[1] = alpha2;
+  fBuiltHms *= (fAlpha[1] == alpha2);
+  fAlpha[1] = alpha2;
+
 }
 
-//......................................................................
+//.............................................................................
 ///
-/// Reimplement SetIsNuBar to also rebuild hamiltonian..
+/// Reimplement SetIsNuBar to also rebuild hamiltonian.
+///
+/// @param isNuBar - true if antineutrinos
 ///
 void PMNS_Decay::SetIsNuBar(bool isNuBar)
 {
+
   // Check if value is actually changing
   fGotES *= (fIsNuBar == isNuBar);
   fBuiltHms *= (fIsNuBar == isNuBar);
   fIsNuBar = isNuBar;
+
 }
 
-//......................................................................
+//.............................................................................
 ///
 /// Set both mass-splittings at once.
 ///
@@ -110,43 +127,54 @@ void PMNS_Decay::SetIsNuBar(bool isNuBar)
 /// @param dm21 - The solar mass-splitting Dm_21 
 /// @param dm32 - The atmospheric mass-splitting Dm_32 
 ///
-void PMNS_Decay::SetDeltaMsqrs(double dm21, double dm32) 
+void PMNS_Decay::SetDeltaMsqrs(double dm21, double dm32)
 {
+
   SetDm(2, dm21);
   SetDm(3, dm32 + dm21);
+
 }
 
-//
-/// Get alpha3
-double PMNS_Decay::GetAlpha3() 
+//.............................................................................
+///
+/// Get alpha3 parameter
+///
+/// @return alpha3
+///
+double PMNS_Decay::GetAlpha3()
 {
-  return falpha[2];
+  return fAlpha[2];
 }
 
-/// Get alpha2
+//.............................................................................
+///
+/// Get alpha2 parameter
+///
+/// @return alpha2
+///
 double PMNS_Decay::GetAlpha2()
 {
-  return falpha[1];
+  return fAlpha[1];
 }
 
 
-//......................................................................
+//.............................................................................
 ///
 ///  Implement building decay hamiltonian
 ///
-void PMNS_Decay::BuildHam()
+void PMNS_Decay::BuildHms()
 {
 
   // Check if anything changed
   if(fBuiltHms) return;
-   
+
   // Tag to recompute eigensystem
   fGotES = false;
-  
+
   for(int j=0; j<fNumNus; j++){
     // Set mass splitting
     fHms[j][j] = fDm[j];
-    fHd[j][j] = falpha[j];
+    fHd[j][j] = fAlpha[j];
     // Reset off-diagonal elements
     for(int i=0; i<j; i++){
       fHms[i][j] = 0;
@@ -172,14 +200,14 @@ void PMNS_Decay::BuildHam()
     }
   }
 
-  const complexD numi(0.0,1.0);  
+  const complexD numi(0.0,1.0);
   ///Construct the total Hms+Hd
   for(int j=0; j<fNumNus; j++){
     for(int i=0; i<fNumNus; i++){
       fHms[i][j] = fHms[i][j] - numi*fHd[i][j];
     }
-  }  
- 
+  }
+
   // Clear eigensystem cache
   //ClearCache();
 
@@ -189,7 +217,7 @@ void PMNS_Decay::BuildHam()
 }
 
 
-//......................................................................
+//.............................................................................
 ///
 /// Build the full Hamiltonian in matter.
 ///
@@ -211,13 +239,13 @@ void PMNS_Decay::UpdateHam()
       fHam(i,j) = fHms[i][j]/lv;
     }
   }
- 
+
   if(!fIsNuBar) fHam(0,0) += kr2GNe;
   else          fHam(0,0) -= kr2GNe;
-  
+
 }
 
-//......................................................................
+//.............................................................................
 ///
 /// Solve the full Hamiltonian for eigenvalues.
 ///
@@ -230,7 +258,7 @@ void PMNS_Decay::SolveHam()
 {
 
   // Build Hamiltonian
-  BuildHam();
+  BuildHms();
 
   // Check if anything changed  
   if(fGotES) return;
@@ -250,9 +278,11 @@ void PMNS_Decay::SolveHam()
 
 }
 
-//.....................................................................
+//.............................................................................
 ///
 /// Propagate the neutrino through a constant density path
+///
+/// @param p - The neutrino path
 ///
 void PMNS_Decay::PropagatePath(NuPath p)
 {
@@ -261,7 +291,7 @@ void PMNS_Decay::PropagatePath(NuPath p)
   SetCurPath(p);
 
   // Build Hamiltonian
-  BuildHam();
+  BuildHms();
   UpdateHam();
 
   double LengthIneV = kKm2eV * p.length;
@@ -283,7 +313,7 @@ void PMNS_Decay::PropagatePath(NuPath p)
   for(int i=0;i<fNumNus;i++){
     fNuState[i] = fBuffer[i];
   }
-  
+
 }
 
 

--- a/src/complexsolver.cxx
+++ b/src/complexsolver.cxx
@@ -27,5 +27,5 @@ void complexsolver(const Eigen::MatrixXcd& A,
   for(int t=0; t<w.size(); t++){
     w[t] = eigensolver.eigenvalues()(t).real();
   }
- 
+
 }

--- a/src/complexsolver.cxx
+++ b/src/complexsolver.cxx
@@ -1,40 +1,31 @@
 
 #include <iostream>
 
-#include "Eigen/Eigenvalues"
+#include <Eigen/Eigenvalues>
 
 #include "complexsolver.h"
 
 //.............................................................................
 ///
-/// Wrapper to solve non-hermitian matrix eigensystem.
+/// Wrapper to solve non-hermitian matrix eigenvalues.
 ///
 /// @param A    - Input matrix
-/// @param Q    - Output eigenvectors
-/// @param Qinv - Inverse eigenvectors
 /// @param w    - Output eigenvalues
 ///
-void complexsolver(OscProb::matrixC  A,
+void complexsolver(const Eigen::MatrixXcd& A,
                    OscProb::vectorD& w)
 {
 
-  int size=w.size();
-  Eigen::MatrixXcd l(size,size);
-  Eigen::VectorXcd evl(size);
-  
-  for(int n=0; n<size; n++){
-    for(int m=0; m<size; m++){
-      l(n,m)=A[n][m];
-    } 
-  }
-                  
   Eigen::ComplexEigenSolver<Eigen::MatrixXcd> eigensolver;
-  eigensolver.compute(l);
+  eigensolver.compute(A);
 
-  evl = eigensolver.eigenvalues();
+  if(eigensolver.info() != Eigen::Success){
+    std::cerr << "ERROR: The diagonalization is failing" << std::endl;
+    abort();
+  }
 
-  for(int t=0; t<size; t++){
-    w[t] = evl(t).real();
+  for(int t=0; t<w.size(); t++){
+    w[t] = eigensolver.eigenvalues()(t).real();
   }
  
 }

--- a/src/complexsolver.cxx
+++ b/src/complexsolver.cxx
@@ -1,6 +1,8 @@
 
 #include <iostream>
 
+#include "Eigen/Eigenvalues"
+
 #include "complexsolver.h"
 
 //.............................................................................
@@ -13,41 +15,26 @@
 /// @param w    - Output eigenvalues
 ///
 void complexsolver(OscProb::matrixC  A,
-                   OscProb::matrixC& Q,
-                   OscProb::matrixC& Qinv,
-                   OscProb::vectorC& w)
+                   OscProb::vectorD& w)
 {
 
   int size=w.size();
   Eigen::MatrixXcd l(size,size);
-  Eigen::MatrixXcd evc(size,size), evcinv(size,size);
   Eigen::VectorXcd evl(size);
   
   for(int n=0; n<size; n++){
     for(int m=0; m<size; m++){
       l(n,m)=A[n][m];
     } 
-  }  
+  }
                   
   Eigen::ComplexEigenSolver<Eigen::MatrixXcd> eigensolver;
   eigensolver.compute(l);
- 
-  if(eigensolver.info() != Eigen::Success){
-    std::cerr << "ERROR: The diagonalization is failing" << std::endl;
-    abort();
-  }
-  
+
   evl = eigensolver.eigenvalues();
-  evc= eigensolver.eigenvectors();
-  evcinv=evc.inverse();
-  for(int n=0; n<size; n++){
-    for(int m=0; m<size; m++){
-      Q[n][m] = evc(n,m);
-      Qinv[n][m]= evcinv(n,m);
-    }
-  }  
+
   for(int t=0; t<size; t++){
-    w[t] = evl(t);
+    w[t] = evl(t).real();
   }
-              
+ 
 }

--- a/test/CheckProbs.C
+++ b/test/CheckProbs.C
@@ -2,16 +2,15 @@
 
 int CheckProbs(){
 
-  vector<string> models = {"Fast", "Iter", "Sterile", "NSI", "Deco", "Decay",
-                           "LIV", "SNSI"};
+  vector<string> models = GetListOfModels();
 
   for(int i=0; i<models.size(); i++){
 
-    OscProb::PMNS_Base* p = GetModel(models[i]);  
+    OscProb::PMNS_Base* p = GetModel(models[i]);
 
     if(CheckProb(p, "PMNS_"+models[i]+"_test_values.root")) return 1;
   }
 
   return 0;
-  
+
 }

--- a/test/StressTest.C
+++ b/test/StressTest.C
@@ -29,8 +29,8 @@ struct TimeIt {
     if(tpi<1){ tpi *= 1e3; scale = "ms"; }
     if(tpi<1){ tpi *= 1e3; scale = "µs"; }
     if(tpi<1){ tpi *= 1e3; scale = "ns"; }
-    cout << "Performance = " 
-         << TString::Format(tpi>10 ? "%.0f" : "%.1f",tpi) 
+    cout << "Performance = "
+         << TString::Format(tpi>9.95 ? "%.0f" : "%.1f",tpi)
          << " " << scale << "/iteration" << endl;
   }
 
@@ -69,15 +69,16 @@ void TimeTest(OscProb::PMNS_Base* p, string model, int max_length){
   for(int k=0; k<100 && time.time()<1; k++){
     p->ClearCache(); // Clear cache at each iteration
     // Compute AvgProb for the energy range
-    for(int i=0; i<=nbins; i++){
-      double energy = xbins[i];
-      p->AvgProb(1,0, energy, 0.2*energy);
+    for(int i=0; i<nbins; i++){
+      double energy = 0.5*(xbins[i] + xbins[i+1]);
+      double dE = xbins[i+1] - xbins[i];
+      p->AvgProb(1,0, energy, dE);
       time.count++;
     }
   }
-  
+
   // Print performance estimate
-  cout << "PMNS_" << model << ": " 
+  cout << "PMNS_" << model << ": "
        << string(max_length - model.size(), ' ');
   time.Print();
 
@@ -89,8 +90,7 @@ void TimeTest(OscProb::PMNS_Base* p, string model, int max_length){
 ///
 int StressTest(){
 
-  vector<string> models = {"Fast", "Iter", "Sterile", "NSI",
-                           "Deco", "Decay", "LIV", "SNSI"};
+  vector<string> models = GetListOfModels();
 
   // Keep track of the longest name
   int max_length = 0;
@@ -107,5 +107,5 @@ int StressTest(){
   }
 
   return 0;
-  
+
 }

--- a/test/StressTest.C
+++ b/test/StressTest.C
@@ -1,0 +1,111 @@
+
+#include "Utils.h"
+
+using hrc = std::chrono::high_resolution_clock;
+using std::chrono::nanoseconds;
+using std::chrono::duration_cast;
+
+//.............................................................................
+///
+/// Timing performance utility
+///
+struct TimeIt {
+
+  // Constructor
+  TimeIt() { reset(); }
+
+  // Reset the clock
+  void reset(){ count = 0; start = hrc::now(); }
+
+  // Return elapsed time in seconds
+  double time(){
+    return 1e-9 * duration_cast<nanoseconds>(hrc::now() - start).count();
+  }
+
+  // Print performance metric
+  void Print(){
+    double tpi = time() / count;
+    string scale = "s";
+    if(tpi<1){ tpi *= 1e3; scale = "ms"; }
+    if(tpi<1){ tpi *= 1e3; scale = "µs"; }
+    if(tpi<1){ tpi *= 1e3; scale = "ns"; }
+    cout << "Performance = " 
+         << TString::Format(tpi>10 ? "%.0f" : "%.1f",tpi) 
+         << " " << scale << "/iteration" << endl;
+  }
+
+  // Member attributes
+  hrc::time_point start; // start time
+  int count; // number of iterations
+
+};
+
+
+//.............................................................................
+///
+/// Test the speed performance of a given PMNS object
+///
+void TimeTest(OscProb::PMNS_Base* p, string model, int max_length){
+
+  // Use a PremModel to make paths
+  // through the earth
+  OscProb::PremModel prem;
+
+  // Chose an angle for the neutrino
+  // and fill the paths with cosTheta
+  // e.g. cosTheta = -1 (vertical up-going)
+  prem.FillPath(-1);
+
+  // Give the path to the PMNS object
+  // and get the probability
+  p->SetPath(prem.GetNuPath());
+
+  // Define energy sample points
+  int nbins = 100;
+  vector<double> xbins = GetLogAxis(nbins, 1, 100);
+
+  // Time the AvgProb performance for at most 1s
+  TimeIt time;
+  for(int k=0; k<100 && time.time()<1; k++){
+    p->ClearCache(); // Clear cache at each iteration
+    // Compute AvgProb for the energy range
+    for(int i=0; i<=nbins; i++){
+      double energy = xbins[i];
+      p->AvgProb(1,0, energy, 0.2*energy);
+      time.count++;
+    }
+  }
+  
+  // Print performance estimate
+  cout << "PMNS_" << model << ": " 
+       << string(max_length - model.size(), ' ');
+  time.Print();
+
+}
+
+//.............................................................................
+///
+/// Run the time test over all models
+///
+int StressTest(){
+
+  vector<string> models = {"Fast", "Iter", "Sterile", "NSI",
+                           "Deco", "Decay", "LIV", "SNSI"};
+
+  // Keep track of the longest name
+  int max_length = 0;
+  for(int i=0; i<models.size(); i++){
+    max_length = max(int(models[i].size()), max_length);
+  }
+
+  for(int i=0; i<models.size(); i++){
+
+    OscProb::PMNS_Base* p = GetModel(models[i]);
+
+    TimeTest(p, models[i], max_length);
+
+  }
+
+  return 0;
+  
+}

--- a/test/TestMethods.C
+++ b/test/TestMethods.C
@@ -2,11 +2,11 @@
 
 //.............................................................................
 bool TestAvgProb(OscProb::PMNS_Base* p, double energy, double &max_diff){
- 
+
   double dE = 0.1 * energy;
   double prec = 1e-4;
   p->SetAvgProbPrec(prec);
-  
+
   for(int flvi=0; flvi<3; flvi++){
   for(int flvf=0; flvf<3; flvf++){
 
@@ -18,13 +18,13 @@ bool TestAvgProb(OscProb::PMNS_Base* p, double energy, double &max_diff){
       double energy_i = energy + dE*((i+0.5)/npts - 0.5);
       avg_test += p->Prob(flvi, flvf, energy_i) / npts;
     }
-    
+
     if(abs(avg_prob - avg_test) > max_diff){
       max_diff = abs(avg_prob - avg_test);
     }
 
     if(abs(avg_prob - avg_test) > 5*prec){
-      cerr << "Found mismatch in AvgProb(" 
+      cerr << "Found mismatch in AvgProb("
            << flvi << ", " << flvf << ", "
            << energy << ", " << dE << "): "
            << avg_prob << " - " << avg_test
@@ -35,18 +35,18 @@ bool TestAvgProb(OscProb::PMNS_Base* p, double energy, double &max_diff){
     }
 
   }}
-  
+
   return true;
 
 }
 
 //.............................................................................
 bool TestParallel(OscProb::PMNS_Base* p, double energy){
- 
+
   p->SetEnergy(energy);
 
   OscProb::matrixD pmatrix = p->ProbMatrix(3,3);
- 
+
   for(int flvi=0; flvi<3; flvi++){
 
     OscProb::vectorD pvector = p->ProbVector(flvi);
@@ -56,7 +56,7 @@ bool TestParallel(OscProb::PMNS_Base* p, double energy){
       double prob = p->Prob(flvi, flvf);
 
       if(abs(prob - pmatrix[flvi][flvf]) > 1e-12){
-        cerr << "Found mismatch in ProbMatrix(" 
+        cerr << "Found mismatch in ProbMatrix("
              << flvi << ", " << flvf << "): "
              << prob << " - " << pmatrix[flvi][flvf]
              << " = " << prob - pmatrix[flvi][flvf]
@@ -67,7 +67,7 @@ bool TestParallel(OscProb::PMNS_Base* p, double energy){
       }
 
       if(abs(prob - pvector[flvf]) > 1e-12){
-        cerr << "Found mismatch in ProbVector(" 
+        cerr << "Found mismatch in ProbVector("
              << flvi << ", " << flvf << "): "
              << prob << " - " << pvector[flvf]
              << " = " << prob - pvector[flvf]
@@ -80,7 +80,7 @@ bool TestParallel(OscProb::PMNS_Base* p, double energy){
     }
 
   }
-  
+
   return true;
 
 }
@@ -111,7 +111,7 @@ bool TestNominal(string model, double &max_diff){
 
     p->SetIsNuBar(isnb);
     p0.SetIsNuBar(isnb);
-    
+
     for(int i=0; i<=nbins; i++){
 
       double energy = xbins[i];
@@ -127,19 +127,19 @@ bool TestNominal(string model, double &max_diff){
         }
 
         if(abs(nom_prob - alt_prob) > prec){
-          cerr << "Found mismatch in nominal Prob(" 
+          cerr << "Found mismatch in nominal Prob("
                << flvi << ", " << flvf << ", " << energy << "): "
                << nom_prob << " - " << alt_prob
                << " = " << nom_prob - alt_prob
                << "; with IsNuBar = " << p->GetIsNuBar()
                << endl;
-          cerr << "FAILED: Model PMNS_" << model 
+          cerr << "FAILED: Model PMNS_" << model
                << " comparison to nominal" << endl;
           return false;
         }
 
       }}
-  
+
     }
 
   }
@@ -164,19 +164,19 @@ bool TestMethodsModel(OscProb::PMNS_Base* p, string model){
   for(int isnb=0; isnb<2; isnb++){
 
     p->SetIsNuBar(isnb);
-      
+
     for(int i=0; i<=nbins; i++){
 
       double energy = xbins[i];
-      
+
       if(!TestAvgProb(p, energy, avg_max_diff)){
-        cerr << "FAILED: Model PMNS_" << model 
+        cerr << "FAILED: Model PMNS_" << model
              << " AvgProb" << endl;
         return false;
       }
 
       if(!TestParallel(p, energy)){
-        cerr << "FAILED: Model PMNS_" << model 
+        cerr << "FAILED: Model PMNS_" << model
              << " parallel methods" << endl;
         return false;
       }
@@ -184,13 +184,13 @@ bool TestMethodsModel(OscProb::PMNS_Base* p, string model){
     }
 
   }
-  
-  cout << "PASSED: PMNS_" << model 
+
+  cout << "PASSED: PMNS_" << model
        << " with max nominal error: "
        << nom_max_diff
        << " and max AvgProb error: "
        << avg_max_diff << endl;
-  
+
   return true;
 
 }
@@ -198,8 +198,7 @@ bool TestMethodsModel(OscProb::PMNS_Base* p, string model){
 //.............................................................................
 int TestMethods(){
 
-  vector<string> models = {"Fast", "Iter", "Sterile", "NSI", "Deco", "Decay",
-                           "LIV", "SNSI"};
+  vector<string> models = GetListOfModels();
 
   for(int i=0; i<models.size(); i++){
 
@@ -209,7 +208,7 @@ int TestMethods(){
     delete p;
 
   }
-  
+
   return 0;
 
 }

--- a/test/Utils.h
+++ b/test/Utils.h
@@ -1,4 +1,6 @@
 
+#include "../tutorial/SetNiceStyle.C"
+
 OscProb::PMNS_Fast* GetFast(bool is_nominal){
 
   return new OscProb::PMNS_Fast();

--- a/test/Utils.h
+++ b/test/Utils.h
@@ -1,18 +1,21 @@
 
 #include "../tutorial/SetNiceStyle.C"
 
+//.............................................................................
 OscProb::PMNS_Fast* GetFast(bool is_nominal){
 
   return new OscProb::PMNS_Fast();
 
 }
 
+//.............................................................................
 OscProb::PMNS_Iter* GetIter(bool is_nominal){
 
   return new OscProb::PMNS_Iter();
 
 }
 
+//.............................................................................
 OscProb::PMNS_Deco* GetDeco(bool is_nominal){
 
   OscProb::PMNS_Deco* p = new OscProb::PMNS_Deco();
@@ -20,11 +23,12 @@ OscProb::PMNS_Deco* GetDeco(bool is_nominal){
     p->SetGamma(2, 1e-23);
     p->SetGamma(3, 1e-22);
   }
-  
+
   return p;
 
 }
 
+//.............................................................................
 OscProb::PMNS_Sterile* GetSterile(bool is_nominal){
 
   OscProb::PMNS_Sterile* p = new OscProb::PMNS_Sterile(4);
@@ -34,22 +38,24 @@ OscProb::PMNS_Sterile* GetSterile(bool is_nominal){
     p->SetAngle(2,4, 0.1);
     p->SetAngle(3,4, 0.1);
   }
-  
+
   return p;
 
 }
 
+//.............................................................................
 OscProb::PMNS_Decay* GetDecay(bool is_nominal){
 
   OscProb::PMNS_Decay* p = new OscProb::PMNS_Decay();
   if(!is_nominal){
     p->SetAlpha3(1e-4);
   }
-  
+
   return p;
 
 }
 
+//.............................................................................
 OscProb::PMNS_NSI* GetNSI(bool is_nominal){
 
   OscProb::PMNS_NSI* p = new OscProb::PMNS_NSI();
@@ -61,11 +67,12 @@ OscProb::PMNS_NSI* GetNSI(bool is_nominal){
     p->SetEps(1,2, 0.5, 0);
     p->SetEps(2,2, 0.6, 0);
   }
-  
+
   return p;
 
 }
 
+//.............................................................................
 OscProb::PMNS_SNSI* GetSNSI(bool is_nominal){
 
   OscProb::PMNS_SNSI* p = new OscProb::PMNS_SNSI();
@@ -77,11 +84,12 @@ OscProb::PMNS_SNSI* GetSNSI(bool is_nominal){
     p->SetEps(1,2, 0.5, 0);
     p->SetEps(2,2, 0.6, 0);
   }
-  
+
   return p;
 
 }
 
+//.............................................................................
 OscProb::PMNS_LIV* GetLIV(bool is_nominal){
 
   OscProb::PMNS_LIV* p = new OscProb::PMNS_LIV();
@@ -99,11 +107,12 @@ OscProb::PMNS_LIV* GetLIV(bool is_nominal){
     p->SetcT(1,2, 0.5e-22, 0);
     p->SetcT(2,2, 0.6e-22, 0);
   }
-  
+
   return p;
 
 }
 
+//.............................................................................
 OscProb::PMNS_Base* GetModel(string model, bool is_nominal = false){
 
   if(model == "Iter")    return GetIter(is_nominal);
@@ -118,6 +127,17 @@ OscProb::PMNS_Base* GetModel(string model, bool is_nominal = false){
 
 }
 
+//.............................................................................
+vector<string> GetListOfModels(){
+
+  //return {"Decay"};
+
+  return {"Fast", "Iter", "Sterile", "NSI",
+          "Deco", "Decay", "LIV", "SNSI"};
+
+}
+
+//.............................................................................
 void SetTestPath(OscProb::PMNS_Base* p){
 
   p->SetPath(1000, 2);
@@ -126,14 +146,15 @@ void SetTestPath(OscProb::PMNS_Base* p){
 
 }
 
+//.............................................................................
 void SaveTestFile(OscProb::PMNS_Base* p, TString filename){
 
   SetTestPath(p);
-  
+
   int nbins = 100;
   vector<double> xbins = GetLogAxis(nbins, 0.1, 10);
   TH1D* h = 0;
-  
+
   TFile* f = new TFile("data/"+filename, "recreate");
 
   for(int flvi=0; flvi<3; flvi++){
@@ -156,10 +177,11 @@ void SaveTestFile(OscProb::PMNS_Base* p, TString filename){
 
 }
 
+//.............................................................................
 int CheckProb(OscProb::PMNS_Base* p, TString filename){
 
   SetTestPath(p);
-  
+
   TFile* f = new TFile("data/"+filename, "read");
 
   int ntests = 0;
@@ -197,7 +219,7 @@ int CheckProb(OscProb::PMNS_Base* p, TString filename){
       SetHist(h, kRed);
       TString nu_lab = isnb ? "#bar{#nu}" : "#nu";
       TString flv_lab[3] = {"e","#mu","#tau"};
-      TString ylab = "P(" + nu_lab + "_{" + flv_lab[flvi] + 
+      TString ylab = "P(" + nu_lab + "_{" + flv_lab[flvi] +
                      "}#rightarrow" + nu_lab + "_{" + flv_lab[flvf] + "})";
       h0->SetTitle(";Energy [GeV];"+ylab+";");
       h->SetLineStyle(7);


### PR DESCRIPTION
Instead of using a complicated decomposition including the inverse of the eigenvectors, move to directly computing the matrix exponential. Seems to speed up the class by a factor of ~3.