### PR TITLE
Move sterile to eigen

### DIFF
--- a/MainPage.md
+++ b/MainPage.md
@@ -2,7 +2,8 @@
 
 OscProb is a small set of classes aimed at computing exact neutrino oscillation probabilities with a few different models.
 
-OscProb contains a basic framework for computing neutrino oscillation probabilities. It is integrated into [ROOT](https://root.cern.ch/), so that each class can be used as you would any ROOT class.
+OscProb contains a basic framework for computing neutrino oscillation probabilities.
+It is integrated into [ROOT](https://root.cern.ch/), so that each class can be used as you would any ROOT class.
 
 Available classes are:
 - **[PremModel](@ref OscProb::PremModel):** Used for determining neutrino paths through the earth
@@ -13,7 +14,7 @@ Available classes are:
 - **[PMNS_SNSI](@ref OscProb::PMNS_SNSI):** Oscillations with 3 flavours including scalar Non-Standard Interactions
 - **[PMNS_Deco](@ref OscProb::PMNS_Deco):** Oscillations with 3 flavours including a simple decoherence model
 - **[PMNS_LIV](@ref OscProb::PMNS_LIV):** Oscillations with 3 flavours including Lorentz Invariance Violations
-- **[PMNS_Decay](@ref OscProb::PMNS_Decay):** Oscillations with 3 flavours including neutrino decays of the second and third neutrino mass states nu_2 and nu_3. [Requires external library Eigen3, see the instructions below.]
+- **[PMNS_Decay](@ref OscProb::PMNS_Decay):** Oscillations with 3 flavours including neutrino decays
 - **[Absorption](@ref OscProb::Absorption):** Computes absorption probabilities for high-energy neutrinos
 
-A few example macros on how to use OscProb are available in a tutorial directory.
+A few example macros on how to use OscProb are available in a [tutorial](https://github.com/joaoabcoelho/OscProb/tree/master/tutorial) directory.

--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,12 @@ TARGET_LIB = $(CURDIR)/lib/$(TARGET).so
 TARGET_PCM = $(CURDIR)/lib/$(TARGET)_rdict.pcm
 DICTIONARY = $(CURDIR)/tmp/$(TARGET).cxx
 
-# GSL library
-GSL_INCS := $(shell gsl-config --cflags)
-GSL_LIBS := $(shell gsl-config --libs)
-
 #Eigen library
 Eigen_INCS = ${CURDIR}/eigen
 
-INCDIRS = -I$(CURDIR) -I$(CURDIR)/inc $(GSL_INCS) -I$(Eigen_INCS)
+INCDIRS = -I$(CURDIR) -I$(CURDIR)/inc -I$(Eigen_INCS)
 
 override CXXFLAGS += $(INCDIRS)
-override LDFLAGS  += $(GSL_LIBS)
 
 # the sets of directories to do various things in
 MATRIX = $(CURDIR)/MatrixDecomp/libMatrixDecomp.so

--- a/README.md
+++ b/README.md
@@ -4,32 +4,34 @@
 
 OscProb is a small set of classes aimed at computing exact neutrino oscillation probabilities with a few different models.
 
-OscProb contains a basic framework for computing neutrino oscillation probabilities. It is integrated into [ROOT](https://root.cern.ch/), so that each class can be used as you would any ROOT class.
+OscProb contains a basic framework for computing neutrino oscillation probabilities. 
+It is integrated into [ROOT](https://root.cern.ch/), so that each class can be used as you would any ROOT class.
 
 Available classes are:
 - **PremModel:** Used for determining neutrino paths through the earth
 - **PMNS_Fast:** Standard 3-flavour oscillations
-- **PMNS_Iter:** Standard 3-flavour oscillations (iterative)
+- **PMNS_Iter:** Standard 3-flavour oscillations (iterative approximation)
 - **PMNS_Sterile:** Oscillations with any number of neutrinos
 - **PMNS_NSI:** Oscillations with 3 flavours including vector Non-Standard Interactions
 - **PMNS_SNSI:** Oscillations with 3 flavours including scalar Non-Standard Interactions
 - **PMNS_Deco:** Oscillations with 3 flavours including a simple decoherence model
 - **PMNS_LIV:** Oscillations with 3 flavours including Lorentz Invariance Violations
-- **PMNS_Decay:** Oscillations with 3 flavours including neutrino decays of the second and third neutrino mass states \nu_2 and \nu_3. [Requires external library Eigen3, see the instructions below.]
+- **PMNS_Decay:** Oscillations with 3 flavours including neutrino decays
 - **Absorption:** Computes absorption probabilities for high-energy neutrinos
 
-A few example macros on how to use OscProb are available in a tutorial directory.
+A few example macros on how to use OscProb are available in a [tutorial](tutorial) directory.
 
 # Installing OscProb
 
-OscProb is very easy to install. The only requirements is to have ROOT installed with the GSL libraries.
+OscProb is very easy to install. The only requirements is to have ROOT installed.
 
 **NEW: Thanks to Jacek Holeczek, OscProb now also builds with ROOT 6!!**
 
 <details>
   <summary>Details: Eigen</summary>
 
-  In order to compile the PMNS_Decay class, it is necessary to donwload the external Eigen library. This library is added as a submodule and will be downloaded by make.
+  In order to compile the `PMNS_Decay` and `PMNS_Sterile` classes, it is necessary to 
+  donwload the external Eigen library. This library is added as a submodule and will be downloaded by make.
 
   Alternatively, you can trigger them manually with:
   * During cloning: `git clone --recurse-submodules https://github.com/joaoabcoelho/OscProb.git`

--- a/inc/PMNS_Sterile.h
+++ b/inc/PMNS_Sterile.h
@@ -1,59 +1,50 @@
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 /// \class OscProb::PMNS_Sterile
 ///
 /// \brief Implementation of oscillations of neutrinos in matter in a
 ///        N-neutrino framework.
 ///
-/// This class implements neutrino oscillations for any number of 
+/// This class implements neutrino oscillations for any number of
 /// neutrino falvours. The extra flavours above 3 are treated as
 /// sterile neutrinos, i.e. it implements a 3+N model. One can also
 /// run a 2-neutrino model in principle, but an analytical solution
 /// would be feasible and more efficient in that case.
 ///
-/// The eigensystem solution is performed by GSL, which makes it slower
-/// than the PMNS_Fast class, which only works for 3 neutrinos. 
+/// The eigensystem solution is performed by Eigen, which makes it slower
+/// than the PMNS_Fast class, which only works for 3 neutrinos.
 ///
 /// \author jcoelho\@apc.in2p3.fr
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 
 #ifndef PMNS_STERILE_H
 #define PMNS_STERILE_H
 
-#include <gsl/gsl_eigen.h>
+#include <Eigen/Core>
 
 #include "PMNS_Base.h"
 
 namespace OscProb {
 
-  struct GSL_EinSys {
-  
-    GSL_EinSys(int numNus); ///< Constructor
-    GSL_EinSys(const GSL_EinSys &other); ///< Copy-constructor
-    GSL_EinSys& operator=(const GSL_EinSys &other); ///< Copy assignment
-    virtual ~GSL_EinSys();  ///< Destructor
-    
-    int fNumNus;  ///< Number of neutrino flavors
-
-    gsl_vector* fEvalGSL;             ///< Stores the GSL eigenvalues
-    gsl_matrix_complex* fEvecGSL;     ///< Stores the GSL eigenvectors
-    gsl_matrix_complex* H_GSL;        ///< The Hamiltonian to be solved by GSL
-    gsl_eigen_hermv_workspace* W_GSL; ///< Allocates memory for GSL solution
-
-  };
-
   class PMNS_Sterile : public PMNS_Base {
+
     public:
 
-    PMNS_Sterile(int NumNus); ///< Constructor
-    
-  protected:
-    
-    /// Solve the full Hamiltonian for eigenvectors and eigenvalues
-    virtual void SolveHam();
-    
-    GSL_EinSys fGSL;
+      PMNS_Sterile(int numNus); ///< Constructor
+
+    protected:
+
+      /// Build the full Hamiltonian
+      virtual void UpdateHam();
+
+      /// Solve the full Hamiltonian for eigenvectors and eigenvalues
+      virtual void SolveHam();
+
+      Eigen::MatrixXcd fHam;
 
   };
+
 }
+
 #endif
-////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////

--- a/src/PMNS_Sterile.cxx
+++ b/src/PMNS_Sterile.cxx
@@ -1,9 +1,9 @@
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 //
 // Implementation of oscillations of neutrinos in matter in a
-// n-neutrino framework. 
+// n-neutrino framework.
 //
-//......................................................................
+//.............................................................................
 //
 // Throughout I have taken:
 //   - L to be the neutrino flight distance in km
@@ -13,9 +13,11 @@
 //   - theta_ij and delta_ij to be in radians
 //
 // jcoelho\@apc.in2p3.fr
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 
-#include <gsl/gsl_complex_math.h>
+#include <iostream>
+
+#include <Eigen/Eigenvalues>
 
 #include "PMNS_Sterile.h"
 
@@ -23,104 +25,7 @@ using namespace std;
 
 using namespace OscProb;
 
-//......................................................................
-///
-/// GSL Eigensystem Constructor.
-///
-/// @param numNus - the number of neutrino flavours
-///
-GSL_EinSys::GSL_EinSys(int numNus) : 
-fNumNus(numNus), 
-fEvalGSL(0), fEvecGSL(0), H_GSL(0), W_GSL(0)
-{
-
-  // Allocate memory for the GSL objects
-  fEvalGSL = gsl_vector_alloc(fNumNus);
-  fEvecGSL = gsl_matrix_complex_alloc(fNumNus, fNumNus);
-  H_GSL = gsl_matrix_complex_alloc(fNumNus, fNumNus);
-  W_GSL = gsl_eigen_hermv_alloc(fNumNus);
-
-}
-
-//......................................................................
-///
-/// GSL Copy-constructor.
-///
-/// Allocate new memory for GSL objects when copying.
-///
-/// @param other - GSL object to copy
-///
-GSL_EinSys::GSL_EinSys(const GSL_EinSys &other) :
-fNumNus(other.fNumNus), 
-fEvalGSL(0), fEvecGSL(0), H_GSL(0), W_GSL(0)
-{
-
-  // Allocate memory for the GSL objects
-  fEvalGSL = gsl_vector_alloc(fNumNus);
-  fEvecGSL = gsl_matrix_complex_alloc(fNumNus, fNumNus);
-  H_GSL = gsl_matrix_complex_alloc(fNumNus, fNumNus);
-  W_GSL = gsl_eigen_hermv_alloc(fNumNus);
-
-  gsl_vector_memcpy(fEvalGSL, other.fEvalGSL);
-  gsl_matrix_complex_memcpy(fEvecGSL, other.fEvecGSL);
-  gsl_matrix_complex_memcpy(H_GSL, other.H_GSL);
-
-}
-
-//......................................................................
-///
-/// Copy assignment operator.
-///
-/// Creates a new deep copy of object..
-///
-/// @param other - GSL object to assign
-///
-GSL_EinSys& GSL_EinSys::operator=(const GSL_EinSys &other)
-{
-
-  if(fNumNus != other.fNumNus){
- 
-    // Free memory from GSL objects
-    gsl_matrix_complex_free(H_GSL); H_GSL = 0;
-    gsl_eigen_hermv_free(W_GSL); W_GSL = 0;
-    gsl_matrix_complex_free(fEvecGSL); fEvecGSL = 0;
-    gsl_vector_free(fEvalGSL); fEvalGSL = 0;
-
-    fNumNus = other.fNumNus;
-
-    // Allocate memory for the GSL objects
-    fEvalGSL = gsl_vector_alloc(fNumNus);
-    fEvecGSL = gsl_matrix_complex_alloc(fNumNus, fNumNus);
-    H_GSL = gsl_matrix_complex_alloc(fNumNus, fNumNus);
-    W_GSL = gsl_eigen_hermv_alloc(fNumNus);
- 
-  }
-
-  gsl_vector_memcpy(fEvalGSL, other.fEvalGSL);
-  gsl_matrix_complex_memcpy(fEvecGSL, other.fEvecGSL);
-  gsl_matrix_complex_memcpy(H_GSL, other.H_GSL);
-  
-  return *this;
-
-}
-
-//......................................................................
-///
-/// Destructor.
-///
-/// Clear GSL objects.
-///
-GSL_EinSys::~GSL_EinSys(){
-
-  // Free memory from GSL objects
-  gsl_matrix_complex_free(H_GSL); H_GSL = 0;
-  gsl_eigen_hermv_free(W_GSL); W_GSL = 0;
-  gsl_matrix_complex_free(fEvecGSL); fEvecGSL = 0;
-  gsl_vector_free(fEvalGSL); fEvalGSL = 0;
-
-}
-
-//......................................................................
+//.............................................................................
 ///
 /// Constructor. \sa PMNS_Base::PMNS_Base
 ///
@@ -129,9 +34,56 @@ GSL_EinSys::~GSL_EinSys(){
 /// @param numNus - the number of neutrino flavours
 ///
 PMNS_Sterile::PMNS_Sterile(int numNus) :
-PMNS_Base(numNus), fGSL(numNus) {}
+PMNS_Base(numNus), fHam(numNus, numNus) {}
 
-//......................................................................
+
+//.............................................................................
+///
+/// Build the full Hamiltonian in matter.
+///
+/// Here we divide the mass squared matrix Hms by the 2E
+/// to obtain the vacuum Hamiltonian in eV. Then, the matter
+/// potential is added to the electron and NC components.
+///
+void PMNS_Sterile::UpdateHam(){
+
+  double rho = fPath.density;
+  double zoa = fPath.zoa;
+
+  double lv = 2 * kGeV2eV*fEnergy;                 // 2E in eV
+  double kr2GNe = kK2*M_SQRT2*kGf * rho*zoa;       // Electron matter potential in eV
+  double kr2GNn = kK2*M_SQRT2*kGf * rho*(1-zoa)/2; // Neutron matter potential in eV
+
+  // Finish building Hamiltonian in matter with dimension of eV
+  for(int i=0; i<fNumNus; i++){
+
+    // Set diagonal elements which are real
+    fHam(i,i) = fHms[i][i]/lv;
+
+    // Set off-diagonal elements and flip deltaCP if needed
+    for(int j=i+1; j<fNumNus; j++){
+      // Obs: fHam is lower tirangular while fHms is upper triangular
+      if(!fIsNuBar) fHam(j,i) = fHms[i][j]/lv;
+      else          fHam(j,i) = conj(fHms[i][j])/lv;
+    }
+
+    // Subtract NC coherent forward scattering from sterile neutrinos.
+    // See arXiv:hep-ph/0606054v3, eq. 3.15, for example.
+    if(i>2){
+      if(!fIsNuBar) fHam(i,i) += kr2GNn;
+      else          fHam(i,i) -= kr2GNn;
+    }
+
+  }
+
+  // Add nue CC coherent forward scattering.
+  if(!fIsNuBar) fHam(0,0) += kr2GNe;
+  else          fHam(0,0) -= kr2GNe;
+
+}
+
+
+//.............................................................................
 ///
 /// Build and solve the full Hamiltonian for eigenvectors and eigenvalues.
 ///
@@ -151,53 +103,28 @@ void PMNS_Sterile::SolveHam()
 
   // Check if anything changed
   if(fGotES) return;
-  
-  // Try caching if activated  
+
+  // Try caching if activated
   if(TryCache()) return;
 
-  double rho = fPath.density;
-  double zoa = fPath.zoa;
-
-  double lv = 2 * kGeV2eV*fEnergy;                 // 2E in eV 
-  double kr2GNe = kK2*M_SQRT2*kGf * rho*zoa;       // Electron matter potential in eV
-  double kr2GNn = kK2*M_SQRT2*kGf * rho*(1-zoa)/2; // Neutron matter potential in eV
-
-  // Finish building Hamiltonian in matter with dimension of eV
-  for(size_t i=0;i<size_t(fNumNus);i++){
-    complexD buf = fHms[i][i]/lv;
-    *gsl_matrix_complex_ptr(fGSL.H_GSL, i, i) = gsl_complex_rect(real(buf),0);
-    for(size_t j=i+1;j<size_t(fNumNus);j++){
-      buf = fHms[i][j]/lv;
-      if(!fIsNuBar) *gsl_matrix_complex_ptr(fGSL.H_GSL, j, i) = gsl_complex_rect(real(buf),-imag(buf));
-      else          *gsl_matrix_complex_ptr(fGSL.H_GSL, j, i) = gsl_complex_rect(real(buf), imag(buf));
-    }
-    if(i>2){
-      // Subtract NC coherent forward scattering from sterile neutrinos. See arXiv:hep-ph/0606054v3, eq. 3.15, for example. 
-      if(!fIsNuBar) *gsl_matrix_complex_ptr(fGSL.H_GSL, i, i) = gsl_complex_add_real(gsl_matrix_complex_get(fGSL.H_GSL,i,i) ,  kr2GNn);
-      else          *gsl_matrix_complex_ptr(fGSL.H_GSL, i, i) = gsl_complex_add_real(gsl_matrix_complex_get(fGSL.H_GSL,i,i) , -kr2GNn);;
-    }
-  }
-  // Add nue CC coherent forward scattering from sterile neutrinos. 
-  if(!fIsNuBar) *gsl_matrix_complex_ptr(fGSL.H_GSL, 0, 0) = gsl_complex_add_real(gsl_matrix_complex_get(fGSL.H_GSL,0,0) ,  kr2GNe);
-  else          *gsl_matrix_complex_ptr(fGSL.H_GSL, 0, 0) = gsl_complex_add_real(gsl_matrix_complex_get(fGSL.H_GSL,0,0) , -kr2GNe);
+  UpdateHam();
 
   // Solve Hamiltonian for eigensystem
-  gsl_eigen_hermv(fGSL.H_GSL, fGSL.fEvalGSL, fGSL.fEvecGSL, fGSL.W_GSL);
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXcd> eigensolver(fHam);
 
   // Fill fEval and fEvec vectors from GSL objects
-  for(int i=0;i<fNumNus;i++){
-    fEval[i] = gsl_vector_get(fGSL.fEvalGSL,i);
-    for(int j=0;j<fNumNus;j++){
-      gsl_complex buf = gsl_matrix_complex_get(fGSL.fEvecGSL,i,j);
-      fEvec[i][j] = complexD( GSL_REAL(buf), GSL_IMAG(buf) );
+  for(int i=0; i<fNumNus; i++){
+    fEval[i] = eigensolver.eigenvalues()(i);
+    for(int j=0; j<fNumNus; j++){
+      fEvec[i][j] = eigensolver.eigenvectors()(i,j);
     }
   }
-  
+
   fGotES = true;
-  
-  // Fill cache if activated  
+
+  // Fill cache if activated
   FillCache();
-  
+
 }
 
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Simplify things by removing the dependency on GSL and instead using Eigen for `PMNS_Sterile`.
This also seems to give us ~10% improvement in speed. 