### PR TITLE
Install eigen header files for dependent projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,33 +94,38 @@ target_include_directories(
   OscProb
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/inc>
          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
-list(
-  APPEND
-  PUB_HDRS
-  inc/Absorption.h
-  inc/EarthModelBase.h
-  inc/EarthModelBinned.h
-  inc/EigenPoint.h
-  inc/NuPath.h
-  inc/PMNS_Base.h
-  inc/PMNS_Maltoni.h
-  inc/PMNS_Decay.h
-  inc/PMNS_Deco.h
-  inc/PMNS_DensityMatrix.h
-  inc/PMNS_Fast.h
-  inc/PMNS_Iter.h
-  inc/PMNS_LIV.h
-  inc/PMNS_NSI.h
-  inc/PMNS_NUNM.h
-  inc/PMNS_OQS.h
-  inc/PMNS_SNSI.h
-  inc/PMNS_Sterile.h
-  inc/PMNS_Avg.h
-  inc/PremModel.h
-  inc/Definitions.h
-  ${PROJECT_BINARY_DIR}/prem_default.hpp)
-set_target_properties(OscProb PROPERTIES PUBLIC_HEADER "${PUB_HDRS}" OUTPUT_NAME
-                                                                     OscProb)
+
+set(hdrs
+    Absorption.h
+    EarthModelBase.h
+    EarthModelBinned.h
+    EigenPoint.h
+    NuPath.h
+    PMNS_Base.h
+    PMNS_Maltoni.h
+    PMNS_Decay.h
+    PMNS_Deco.h
+    PMNS_DensityMatrix.h
+    PMNS_Fast.h
+    PMNS_Iter.h
+    PMNS_LIV.h
+    PMNS_NSI.h
+    PMNS_NUNM.h
+    PMNS_OQS.h
+    PMNS_SNSI.h
+    PMNS_Sterile.h
+    PMNS_Avg.h
+    PremModel.h
+    Definitions.h)
+
+set(hdrs_full_path ${hdrs})
+list(TRANSFORM hdrs_full_path PREPEND "${PROJECT_SOURCE_DIR}/inc/")
+
+list(APPEND hrds prem_default.hpp)
+list(APPEND hdrs_full_path ${PROJECT_BINARY_DIR}/prem_default.hpp)
+
+set_target_properties(OscProb PROPERTIES PUBLIC_HEADER "${hdrs_full_path}"
+                                         OUTPUT_NAME OscProb)
 
 # Link libraries
 target_link_libraries(
@@ -128,7 +133,7 @@ target_link_libraries(
   PRIVATE MatrixDecomp
   PUBLIC ROOT::Core Eigen3::Eigen)
 
-add_root_dictionary(OscProb HEADERS ${PUB_HDRS} LINKDEF inc/LinkDef.h)
+add_root_dictionary(OscProb HEADERS ${hdrs} LINKDEF inc/LinkDef.h)
 
 add_subdirectory(MatrixDecomp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,15 @@ endif()
 set(CMAKE_INSTALL_RPATH ${basePoint} ${basePoint}/${relDir}
                         ${basePoint}/../../lib)
 
-# include(CTest)
-
 include(dependencies.cmake)
 
 # useful functions to ease declaration of libraries and executables for this
 # project
 include(cmake/functions/CMakeLists.txt)
+
+if(OSCPROB_ENABLE_TESTING)
+  include(CTest)
+endif()
 
 # Add library
 add_library(OscProb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ set_target_properties(OscProb PROPERTIES PUBLIC_HEADER "${PUB_HDRS}" OUTPUT_NAME
 target_link_libraries(
   OscProb
   PRIVATE MatrixDecomp
-  PUBLIC ROOT::RIO Eigen3::Eigen)
+  PUBLIC ROOT::Core Eigen3::Eigen)
 
 add_root_dictionary(OscProb HEADERS ${PUB_HDRS} LINKDEF inc/LinkDef.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,19 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+if(NOT EXISTS "${CMAKE_INSTALL_INCLUDEDIR}/Eigen/Core")
+  # The Eigen version 3.4.0 has some issues with CMake. This ensures that the
+  # headers are installed where expected
+  if(eigen3_POPULATED)
+    set(eigen_inc ${eigen3_SOURCE_DIR})
+  else()
+    get_target_property(eigen_inc Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+  message(STATUS "Explicitly installing Eigen/Core")
+  install(DIRECTORY "${eigen_inc}/Eigen"
+          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+
 include(cmake/packaging/CMakeLists.txt)
 
 if(NOT PROJECT_IS_TOP_LEVEL)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,114 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 27,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "release",
+            "displayName": "Release config",
+            "description": "Release build",
+            "binaryDir": "${sourceDir}/build-release",
+            "installDir": "${sourceDir}/install-release",
+            "cacheVariables": {
+                "BUILD_SHARED_LIBS": {
+                    "type": "BOOL",
+                    "value": "ON"
+                },
+                "CMAKE_BUILD_TYPE": {
+                    "type": "string",
+                    "value": "Release"
+                },
+                "OSCPROB_ENABLE_TESTING": {
+                    "type": "BOOL",
+                    "value": "OFF"
+                }
+            }
+        },
+        {
+            "name": "dev",
+            "displayName": "Development config",
+            "description": "Development build",
+            "binaryDir": "${sourceDir}/build-dev",
+            "installDir": "${sourceDir}/install-dev",
+            "cacheVariables": {
+                "BUILD_SHARED_LIBS": {
+                    "type": "BOOL",
+                    "value": "ON"
+                },
+                "CMAKE_BUILD_TYPE": {
+                    "type": "string",
+                    "value": "dev"
+                },
+                "OSCPROB_ENABLE_TESTING": {
+                    "type": "BOOL",
+                    "value": "ON"
+                }
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "release",
+            "configurePreset": "release",
+            "targets": [
+                "install"
+            ]
+        },
+        {
+            "name": "dev",
+            "configurePreset": "dev",
+            "targets": [
+                "install"
+            ]
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "dev",
+            "configurePreset": "dev",
+            "output": {
+                "outputOnFailure": true
+            },
+            "execution": {
+                "noTestsAction": "error",
+                "stopOnFailure": false,
+                "scheduleRandom": true
+            }
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "release",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "release"
+                },
+                {
+                    "type": "build",
+                    "name": "release"
+                }
+            ]
+        },
+        {
+            "name": "dev",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "dev"
+                },
+                {
+                    "type": "build",
+                    "name": "dev"
+                },
+                {
+                    "type": "test",
+                    "name": "dev"
+                }
+            ]
+        }
+    ]
+}

--- a/MatrixDecomp/CMakeLists.txt
+++ b/MatrixDecomp/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(
 list(APPEND PUB_HDRS_MD zheevc3.h zheevh3.h zheevq3.h zhetrd3.h)
 set_target_properties(MatrixDecomp PROPERTIES PUBLIC_HEADER "${PUB_HDRS_MD}"
                                               OUTPUT_NAME MatrixDecomp)
-target_link_libraries(MatrixDecomp PUBLIC ROOT::RIO)
+target_link_libraries(MatrixDecomp PUBLIC ROOT::Core)
 
 add_root_dictionary(MatrixDecomp HEADERS ${PUB_HDRS_MD} LINKDEF LinkDef.h)
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ This should take a few seconds and you are all set.
   To quickly install it use:
 
   ```shell
+  cmake --workflow --preset release
+  ```
+
+  If your CMake is too old and does not support the worflow oprion, you can install it with:
+
+  ```shell
   build_dir=$PWD/build # Change with the build dir you want
   install_dir=$PWD/install # Change with the install dir you want
   cmake -B $build_dir --install-prefix $install_dir -DCMAKE_BUILD_TYPE=Release -DOSCPROB_ENABLE_TESTING=ON

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -26,8 +26,7 @@ if(NOT TARGET Eigen3::Eigen)
   set(EIGEN_BUILD_DOC OFF)
   FetchContent_Declare(
     Eigen3
-    URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
-        EXCLUDE_FROM_ALL)
+    URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz)
   FetchContent_MakeAvailable(Eigen3)
   if(OLD_BUILD_TESTING)
     set(BUILD_TESTING ${OLD_BUILD_TESTING})

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -14,6 +14,9 @@ find_package(ROOT REQUIRED COMPONENTS Core RIO)
 find_package(Eigen3 QUIET)
 if(NOT TARGET Eigen3::Eigen)
   set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+  if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+  endif()
   # The CMakeLists of eigen3 version 3.4.0 is not well optimized and attempts in
   # compiling lots of targets that we do not use. This code allows at least to
   # disable the testing, while still being able to compile our tests if
@@ -32,5 +35,8 @@ if(NOT TARGET Eigen3::Eigen)
     set(BUILD_TESTING ${OLD_BUILD_TESTING})
   else()
     unset(BUILD_TESTING)
+    message(STATUS "Eigen will be fetched")
   endif()
+else()
+  message(STATUS "Eigen found")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,20 +1,26 @@
 set(files colormod.h Utils.h MakeTestSamples.C StressTest.C TestMethods.C)
 
-# add_library(Test) target_sources(Test PRIVATE Utils.h)
-# set_target_properties(Test PROPERTIES LINKER_LANGUAGE CXX)
-# target_link_libraries(Test PRIVATE OscProb)
+add_library(Test)
+target_sources(Test PRIVATE Utils.h)
+set_target_properties(Test PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(Test PRIVATE OscProb)
 
-# file(COPY ${files} DESTINATION ${PROJECT_BINARY_DIR}/stage/test)
-# file(CREATE_LINK ${CMAKE_CURRENT_LIST_DIR}/data
-# ${PROJECT_BINARY_DIR}/stage/test/data SYMBOLIC)
+file(COPY ${files} DESTINATION ${PROJECT_BINARY_DIR}/stage/test)
+file(CREATE_LINK ${CMAKE_CURRENT_LIST_DIR}/data
+     ${PROJECT_BINARY_DIR}/stage/test/data SYMBOLIC)
 
-# add_test( NAME TestMethods COMMAND ${ROOT_root_CMD} -b -q
-# ${PROJECT_BINARY_DIR}/stage/tutorial/LoadOscProb.C
-# ${PROJECT_BINARY_DIR}/stage/test/TestMethods.C WORKING_DIRECTORY
-# ${PROJECT_SOURCE_DIR}/test) add_test( NAME StressTest COMMAND ${ROOT_root_CMD}
-# -b -q ${PROJECT_BINARY_DIR}/stage/tutorial/LoadOscProb.C
-# ${PROJECT_BINARY_DIR}/stage/test/StressTest.C WORKING_DIRECTORY
-# ${PROJECT_SOURCE_DIR}/test)
+add_test(
+  NAME TestMethods
+  COMMAND
+    ${ROOT_root_CMD} -b -q ${PROJECT_BINARY_DIR}/stage/tutorial/LoadOscProb.C
+    ${PROJECT_BINARY_DIR}/stage/test/TestMethods.C
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
+add_test(
+  NAME StressTest
+  COMMAND
+    ${ROOT_root_CMD} -b -q ${PROJECT_BINARY_DIR}/stage/tutorial/LoadOscProb.C
+    ${PROJECT_BINARY_DIR}/stage/test/StressTest.C
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
 
 install(FILES ${files} DESTINATION ${CMAKE_INSTALL_PREFIX}/test)
 install(DIRECTORY data DESTINATION ${CMAKE_INSTALL_PREFIX}/test/)


### PR DESCRIPTION
The eigen header files were not correctly installed. Everything compiled just fine, also from dependent projects, but when trying to launch a program depending on oscprob after removing the build directory, the eigen headers could not be found.
This PR solves the issue.
It also:
- Fix some ROOT library dependency
- Silence some compilation warning
- Adds tests during compilation
- Adds CMakePresets to further ease the compilation with CMake
- Fix root dictionary generation

The commits are meant to be atomic: please do not squash