### PR TITLE
Include cassert when needed

### DIFF
--- a/src/PMNS_NUNM.cxx
+++ b/src/PMNS_NUNM.cxx
@@ -15,6 +15,7 @@
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <iostream>
+#include <cassert>
 
 using namespace OscProb;
 using namespace std;


### PR DESCRIPTION
The absence of `#include <cassert>` results in an error on modern compilers.
This is fixed by the current pull request.