### PR TITLE
Remove unnecessary LinkDef which breaks in ROOT 6.40.02

### DIFF
--- a/MatrixDecomp/CMakeLists.txt
+++ b/MatrixDecomp/CMakeLists.txt
@@ -12,8 +12,6 @@ set_target_properties(MatrixDecomp PROPERTIES PUBLIC_HEADER "${PUB_HDRS_MD}"
                                               OUTPUT_NAME MatrixDecomp)
 target_link_libraries(MatrixDecomp PUBLIC ROOT::Core)
 
-add_root_dictionary(MatrixDecomp HEADERS ${PUB_HDRS_MD} LINKDEF LinkDef.h)
-
 install(
   TARGETS MatrixDecomp
   EXPORT oscprob

--- a/MatrixDecomp/LinkDef.h
+++ b/MatrixDecomp/LinkDef.h
@@ -1,8 +1,0 @@
-#ifdef __CINT__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-#pragma link C++ nestedclass;
-
-#endif

--- a/MatrixDecomp/Makefile
+++ b/MatrixDecomp/Makefile
@@ -17,30 +17,18 @@ else
 endif
 
 PACKAGE = MatrixDecomp
-HEADERS := $(filter-out $(CURDIR)/LinkDef.h, $(wildcard $(CURDIR)/*.h))
 SOURCES := $(wildcard $(CURDIR)/*.cxx)
 TARGET = lib$(PACKAGE)
 TARGET_LIB = $(CURDIR)/$(TARGET).so
-DICTIONARY = $(CURDIR)/tmp/$(TARGET).cxx
 
 all: $(TARGET_LIB)
 
-$(TARGET_LIB): $(DICTIONARY) $(SOURCES)
+$(TARGET_LIB): $(SOURCES)
 	@echo "  Building $(PACKAGE)..."
 	@$(CXX) $(CXXFLAGS) -O3 -shared -o$@ $^ $(LDFLAGS)
-
-$(DICTIONARY): $(HEADERS) LinkDef.h
-	@echo "  Making dictionary for $(PACKAGE)..."
-	@mkdir -p tmp
-	@$(DICTEXE) -f $@ $(DICTFLAGS) $^
-	@if [ -e $(DICTIONARY:%.cxx=%_rdict.pcm) ] ; then mv -f $(DICTIONARY:%.cxx=%_rdict.pcm) $(CURDIR)/ ; fi # ROOT 6
 
 clean:
 	@echo "  Cleaning $(PACKAGE)..."
 	@rm -f $(TARGET_LIB)
-	@rm -f $(TARGET_LIB:%.so=%_rdict.pcm) # ROOT 6
-	@rm -f $(DICTIONARY)
-	@rm -f $(DICTIONARY:%.cxx=%.h) # ROOT 5
-	@rm -rf tmp
 
 .PHONY: clean all


### PR DESCRIPTION
MatrixDecomp doesn't add anything in LinkDef and this breaks in ROOT 6.40.02. Simply removing the dictionary solves the problem as it's not doing anything anyway.